### PR TITLE
Fixed Binary Searches

### DIFF
--- a/c/algorithm/BinarySearch.c
+++ b/c/algorithm/BinarySearch.c
@@ -12,7 +12,7 @@ void main()
 		large=mid-1;
 		else
 		small=mid+1;
-		mid=(large+small)/2;
+		mid=small+(large-small)/2;
 		if(ch==mid)
 		{
 			f=1;

--- a/c/algorithm/binary_search.c
+++ b/c/algorithm/binary_search.c
@@ -17,7 +17,7 @@ int main()
  
    first = 0;
    last = n - 1;
-   middle = (first+last)/2;
+   middle = first+(first-last)/2;
  
    while (first <= last) {
       if (array[middle] < search)
@@ -29,7 +29,7 @@ int main()
       else
          last = middle - 1;
  
-      middle = (first + last)/2;
+      middle = first + (last - first)/2;
    }
    if (first > last)
       printf("Not found! %d isn't present in the list.\n", search);

--- a/cpp/algorithms/Binary_search.rb
+++ b/cpp/algorithms/Binary_search.rb
@@ -8,12 +8,12 @@ def binary_search(n, arr)
       return true
     elsif middle < n
       i = middle
-      middle = i + j / 2
+      middle = i + (j - i) / 2
     else
       p "Middle is greater than n"
       j = middle
       p "j: #{j}"
-      middle = i + j / 2
+      middle = i + (j - i) / 2
       p "middle: #{middle}"
     end
   end

--- a/cpp/algorithms/binary_search.cpp
+++ b/cpp/algorithms/binary_search.cpp
@@ -4,7 +4,7 @@
 using namespace std;
 int binsearch(int arr[],int ele,int beg,int end){
 	if(end>=beg){
-		int mid=(beg+end)/2;
+		int mid=beg+(end-beg)/2;
 		if(arr[mid]==ele)
 			return mid;
 		else if(arr[mid]<ele)

--- a/cpp/algorithms/binary_search_nonrecursive.cpp
+++ b/cpp/algorithms/binary_search_nonrecursive.cpp
@@ -15,7 +15,7 @@ int main()
 
 	while(f<=l)	//Will run till 1 element left
 	{
-		m = (f+l)/2;
+		m = f+(l-f)/2;
 		if(e==arr[m])
 		{
 			cout<<"Element found at index "<<m<<endl;

--- a/go/algorithms/binarySearch.go
+++ b/go/algorithms/binarySearch.go
@@ -34,7 +34,7 @@ func main() {
 	// the left or right side depending on the value and then continue
 	// to halve until the result has been found.
 	for left <= right {
-		mid := (left + right) / 2
+		mid := left + (right - left) / 2
 
 		if arr[mid] == searchValue {
 			fmt.Println("Found at position: ", mid)

--- a/javascript/algorithms/binarySearch.js
+++ b/javascript/algorithms/binarySearch.js
@@ -2,7 +2,7 @@ function binarySearch(arr, el){
     var beg = 0;
     var end = arr.length - 1;
     while(end >= beg){
-        var mid = Math.floor((end + beg) / 2);
+        var mid = Math.floor(beg + (end - beg) / 2);
         if(arr[mid] === el) return mid;
         else if(arr[mid] < el) beg = mid + 1;
         else end = mid - 1;


### PR DESCRIPTION
A number of the binary search algorithms had "unsafe" midpoint calculations

`(hi+lo)/2` is not overflow safe. A better calculation for the midpoint would be `lo + (hi-lo)/2` since it won't overflow for particularly large values. Google actually suffered from this bug and was one of the first to make the world aware of it. You can read their blog post about it [here](https://ai.googleblog.com/2006/06/extra-extra-read-all-about-it-nearly.html).