### PR TITLE
Fibonacci recursive in Rust with array as Cache

### DIFF
--- a/rust/fibonacci_cache.rs
+++ b/rust/fibonacci_cache.rs
@@ -1,0 +1,19 @@
+fn fibonacci_cache(n: usize, cache: &mut [u128]) -> u128 {
+	let val: u128 = cache[n];
+	if val == 0 {
+		cache[n] = fibonacci_cache(n-1, cache) + fibonacci_cache(n-2, cache);
+	}
+	return cache[n];
+}
+
+
+fn main() {
+	let mut fibs: [u128; 1000] = [0;1000];
+	fibs[0] = 1;
+	fibs[1] = 1;
+
+	// Max value that can be computed without overflow
+	println!("{:?}", u128::max_value()));
+    println!("Fib(185) = {}", fibonacci_cache(185, &mut fibs));
+
+}

--- a/rust/fibonacci_rec.rs
+++ b/rust/fibonacci_rec.rs
@@ -1,0 +1,14 @@
+
+fn fibonacci(n: u64) -> u64 {
+	if n < 2 {
+		return 1;
+	}
+	else {
+		return fibonacci(n-1) + fibonacci(n-2);
+	}
+}
+
+
+fn main() {
+    println!("Fib(40) = {}", fibonacci(41));
+}


### PR DESCRIPTION
Fibonacci implementation with an array as cache to store precalculated values in memory