### PR TITLE
Solved Tower of Hanoi using recursion

### DIFF
--- a/cpp/Towers of Hanoi.cpp
+++ b/cpp/Towers of Hanoi.cpp
@@ -1,0 +1,26 @@
+#include <bits/stdc++.h>
+using namespace std;
+
+void towerOfHanoi(int n, char From_Rod, char To_Rod, char Aux_Rod)
+{
+	if (n == 1) //Base case: When the last disc is left on the 'From' rod
+	{
+		cout << "Move disk 1 from rod " << From_Rod <<" to rod " << To_Rod<<endl;
+		return;
+	}
+	towerOfHanoi(n - 1, From_Rod, Aux_Rod, To_Rod);
+	cout << "Move disk " << n << " from rod " << From_Rod <<
+								" to rod " << To_Rod << endl;
+	towerOfHanoi(n - 1, Aux_Rod, To_Rod, From_Rod);
+}
+
+// Driver code
+int main()
+{
+	int n = 4; // Number of disks
+	towerOfHanoi(n, 'A', 'C', 'B'); // A, B and C are names of rods
+	return 0;
+}
+
+
+


### PR DESCRIPTION
Tower of Hanoi, is a mathematical puzzle which consists of three towers  and more than one rings.
These rings are of different sizes and stacked upon in an ascending order, i.e. the smaller one sits over the larger one. There are other variations of the puzzle where the number of disks increase, but the tower count remains the same.
The mission is to move all the disks to some another tower without violating the sequence of arrangement. A few rules to be followed for Tower of Hanoi are −
1) Only one disk can be moved among the towers at any given time.
2) Only the "top" disk can be removed.
3) No large disk can sit over a small disk.